### PR TITLE
feat: add docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  postgres:
+    image: postgres:15
+    restart: always
+    ports: 
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: "root"
+      POSTGRES_PASSWORD: "rootpass"


### PR DESCRIPTION
close: https://github.com/purinx/pekko-bank/issues/13

開発用にdocker-composeを整備

postgresを起動できるように設定
$ docker-compose up -d
$ psql "postgresql://root:rootpass@127.0.0.1:5432/"
psql (14.19 (Homebrew), server 15.14 (Debian 15.14-1.pgdg13+1))
WARNING: psql major version 14, server major version 15.
         Some psql features might not work.
Type "help" for help.

root=#
\q