### PR TITLE
http serverの追加

### DIFF
--- a/src/main/scala/AccountRoutes.scala
+++ b/src/main/scala/AccountRoutes.scala
@@ -1,0 +1,51 @@
+import org.apache.pekko.actor.typed.{ActorRef, ActorSystem}
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.util.Timeout
+import org.apache.pekko.actor.typed.scaladsl.AskPattern._
+
+import scala.concurrent.duration._
+
+class AccountRoutes(supervisor: ActorRef[BankGuardian.Command])(using ActorSystem[?]) {
+  private given Timeout = Timeout(5.seconds)
+
+  lazy val routes: Route =
+    pathPrefix("account") {
+      pathPrefix(Segment) { id =>
+        val accountId = id
+        path("withdraw" / IntNumber) { value =>
+          post {
+            val result = supervisor.ask[BankAccount.OperationResult] { ref =>
+              BankGuardian.Deliver(BankAccount.Withdraw(value, ref), accountId)
+            }
+            onSuccess(result) {
+              case BankAccount.OperationSucceeded(balance) =>
+                complete(StatusCodes.OK, s"withdraw operation succeeded: newbalance: ${balance}")
+              case BankAccount.OperationFailed(reason) =>
+                complete(StatusCodes.BadRequest, s"reason: ${reason}")
+            }
+          }
+        } ~ path("deposit" / IntNumber) { value =>
+          val result = supervisor.ask[BankAccount.OperationResult] { ref =>
+            BankGuardian.Deliver(BankAccount.Deposit(value, ref), accountId)
+          }
+          onSuccess(result) {
+            case BankAccount.OperationSucceeded(balance) =>
+              complete(StatusCodes.OK, s"deposit operation succeeded: newbalance: ${balance}")
+            case BankAccount.OperationFailed(reason) =>
+              complete(StatusCodes.BadRequest, s"reason: ${reason}")
+          }
+        } ~ path("balance") {
+          get {
+            val result = supervisor.ask[BankAccount.CurrentBalance] { ref =>
+              BankGuardian.Deliver(BankAccount.GetBalance(ref), accountId)
+            }
+            onSuccess(result) { bal =>
+              complete(StatusCodes.OK, s"balance: ${bal.balance}")
+            }
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
pekko-httpを利用してCLIで実装されていたmethodをAPIでも利用できるように機能追加を加えました。


入金API,出金API、残高確認AΠIを実装しています。

以下が動作例です。

```
pekko-bank on  feat-add-routings:main [!?] via 🐳 rancher-desktop is 📦 v0.1.0 via ☕ v17.0.14 via 🆂 v3.7.1
❯ curl -X POST http://localhost:8080/account/account-1234/deposit/10000

deposit operation succeeded: newbalance: 10000%

pekko-bank on  feat-add-routings:main [!?] via 🐳 rancher-desktop is 📦 v0.1.0 via ☕ v17.0.14 via 🆂 v3.7.1
❯ curl -X POST http://localhost:8080/account/account-1234/deposit/10000

deposit operation succeeded: newbalance: 20000%

pekko-bank on  feat-add-routings:main [!?] via 🐳 rancher-desktop is 📦 v0.1.0 via ☕ v17.0.14 via 🆂 v3.7.1
❯ curl http://localhost:8080/account/account-1234/balance

balance: 20000%

pekko-bank on  feat-add-routings:main [!?] via 🐳 rancher-desktop is 📦 v0.1.0 via ☕ v17.0.14 via 🆂 v3.7.1
❯ curl -X POST http://localhost:8080/account/account-1234/withdraw/10000

withdraw operation succeeded: newbalance: 10000%

pekko-bank on  feat-add-routings:main [!?] via 🐳 rancher-desktop is 📦 v0.1.0 via ☕ v17.0.14 via 🆂 v3.7.1
❯ curl http://localhost:8080/account/account-1234/balance

balance: 10000%
```

