### PR TITLE
BankRoutesのアカウント作成処理を専用のアクターに移譲する

### DIFF
--- a/src/main/scala/bank/Main.scala
+++ b/src/main/scala/bank/Main.scala
@@ -3,7 +3,7 @@ package bank
 import org.apache.pekko
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
-import bank.actor.BankGuardian
+import bank.actor.{BankGuardian, AccountRepositoryActor}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -14,20 +14,23 @@ import bank.util.db.DBIORunner
 
 object Main {
   def main(args: Array[String]): Unit = {
-    val system           = ActorSystem(BankGuardian(), "pekko-bank")
-    given ActorSystem[?] = system
-    val config           = ConfigFactory.load()
-    val hikariConfig     = new HikariConfig()
+    val config       = ConfigFactory.load()
+    val hikariConfig = new HikariConfig()
     hikariConfig.setJdbcUrl(config.getString("db.url"))
     hikariConfig.setUsername(config.getString("db.user"))
     hikariConfig.setPassword(config.getString("db.password"))
     hikariConfig.setDriverClassName(config.getString("db.driver"))
 
-    val dataSource             = new HikariDataSource(hikariConfig)
-    val dbIORunner             = new DBIORunner(dataSource)
-    lazy val accountRepository = AccountRepositoryImpl
+    val dataSource        = new HikariDataSource(hikariConfig)
+    val dbIORunner        = new DBIORunner(dataSource)
+    val accountRepository = AccountRepositoryImpl
 
-    val httpRoutes = new BankRoutes(system, accountRepository, dbIORunner).routes
+    val accountRepositoryBehavior = AccountRepositoryActor(accountRepository, dbIORunner)
+    val bankGuardian              = BankGuardian(accountRepositoryBehavior)
+    val system                    = ActorSystem(bankGuardian, "pekko-bank")
+    given ActorSystem[?]          = system
+
+    val httpRoutes = new BankRoutes(system).routes
     Http()
       .newServerAt("0.0.0.0", 8080)
       .bind(httpRoutes)

--- a/src/main/scala/bank/actor/AccountRepositoryActor.scala
+++ b/src/main/scala/bank/actor/AccountRepositoryActor.scala
@@ -1,0 +1,70 @@
+package bank.actor
+
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import bank.domain.account.Account
+import bank.repository.AccountRepository
+import bank.util.db.DBIORunner
+import scala.util.{Success, Failure}
+import zio.{Unsafe, Runtime}
+
+object AccountRepositoryActor {
+
+  sealed trait Command
+  final case class CreateAccount(ownerName: String, replyTo: ActorRef[CreateAccountResult]) extends Command
+
+  sealed trait CreateAccountResult
+  final case class CreateAccountSuccess(account: Account)                        extends CreateAccountResult
+  final case class CreateAccountFailure(ownerName: String, errorMessage: String) extends CreateAccountResult
+  private final case class WrappedCreateAccountResult(
+      result: CreateAccountResult,
+      replyTo: ActorRef[CreateAccountResult],
+  ) extends Command
+
+  private val MaxOperationsInProgress = 10
+
+  def apply(
+      accountRepository: AccountRepository,
+      dbioRunner: DBIORunner,
+  ): Behavior[Command] = next(accountRepository, dbioRunner, operationsInProgress = 0)
+
+  private def next(
+      accountRepository: AccountRepository,
+      dbioRunner: DBIORunner,
+      operationsInProgress: Int,
+  ): Behavior[Command] = {
+    Behaviors.receive { (context, command) =>
+      command match {
+        case CreateAccount(ownerName, replyTo) =>
+          if (operationsInProgress == MaxOperationsInProgress) {
+            replyTo ! CreateAccountFailure(ownerName, s"Max $MaxOperationsInProgress concurrent operations supported")
+            Behaviors.same
+          } else {
+
+            val account = Account.create(ownerName)
+            val io      = dbioRunner.runTx {
+              accountRepository.create(account)
+            }
+            val futureResult = Unsafe.unsafe { implicit unsafe =>
+              Runtime.default.unsafe.runToFuture(io)
+            }
+
+            context.pipeToSelf(futureResult) {
+              // map the Future value to a message, handled by this actor
+              case Success(_) => WrappedCreateAccountResult(CreateAccountSuccess(account), replyTo)
+              case Failure(e) => WrappedCreateAccountResult(CreateAccountFailure(ownerName, e.getMessage), replyTo)
+            }
+            // increase operationsInProgress counter
+            next(accountRepository, dbioRunner, operationsInProgress + 1)
+          }
+
+        case WrappedCreateAccountResult(result, replyTo) =>
+          // send result to original requestor
+          replyTo ! result
+          // decrease operationsInProgress counter
+          next(accountRepository, dbioRunner, operationsInProgress - 1)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
元のコードではルーティング定義を担うBankRoutesの中にリポジトリを実行するロジックが書かれていたが、これをActorの上で行うように変更した。

AccountRepositoryActorを作成し、この中でAccountRepositoryの実行を行うことにした。ここではSend Future result to selfのパターンが利用されている。 https://pekko.apache.org/docs/pekko/1.0/typed/interaction-patterns.html#send-future-result-to-self ドキュメントを真似したので、最大10並列で実行するという制御がされているが、不要なら削ることもできる

次に BankGuradian 経由で AccountRepositoryActor へメッセージを送るようにした。 ここでは Adapted Response のパターンが利用されている。
https://pekko.apache.org/docs/pekko/1.0/typed/interaction-patterns.html#adapted-response ドキュメントの例と微妙に異なる点として、BankGuradian の def accountRepositoryResponseMapper はバックエンドからのレスポンスをルーティングへ返す必要があるため、 replyTo を引数に取る関数として context.messageAdapter を利用している。